### PR TITLE
:arrow_up: Adds Python 3.12 to trove classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 # This is the minimum version of Python that pip will install your package on.


### PR DESCRIPTION
I added Python 3.12 to your trove classifiers. Python 3.12.2 is the most recent release and is stable. 